### PR TITLE
Fix 2 errors: write to closed socket and unblock opportunity for blocked clients

### DIFF
--- a/src/routing/include/mysqlrouter/routing.h
+++ b/src/routing/include/mysqlrouter/routing.h
@@ -52,6 +52,11 @@ extern const int kDefaultDestinationConnectionTimeout;
  */
 extern const unsigned long long kDefaultMaxConnectErrors;
 
+/** @brief Timeout then reset counter for connect or handshake errors per host
+ *
+ */
+extern const unsigned long long kDefaultMaxConnectErrorsTimeout;
+
 /** @brief Default bind address
  *
  */

--- a/src/routing/src/mysql_routing.h
+++ b/src/routing/src/mysql_routing.h
@@ -202,6 +202,8 @@ public:
   bool block_client_host(const std::array<uint8_t, 16> &client_ip_array,
                          const string &client_ip_str, int server = -1);
 
+  bool check_client_errors_time(const std::array<uint8_t, 16> &client_ip_array);
+
   /** @brief Returns a copy of the list of blocked client hosts
    *
    * Returns a copy of the list of the blocked client hosts.

--- a/src/routing/src/mysql_routing.h
+++ b/src/routing/src/mysql_routing.h
@@ -33,6 +33,7 @@
 #include "plugin_config.h"
 
 #include <atomic>
+#include <ctime>
 #include <arpa/inet.h>
 #include <array>
 #include <iostream>
@@ -80,6 +81,7 @@ using mysqlrouter::URI;
  *  use 10.0.11.6 to setup the connection routing.
  *
  */
+
 class MySQLRouting {
 public:
   /** @brief Default constructor
@@ -97,8 +99,14 @@ public:
                int max_connections = routing::kDefaultMaxConnections,
                int destination_connect_timeout = routing::kDefaultDestinationConnectionTimeout,
                unsigned long long max_connect_errors = routing::kDefaultMaxConnectErrors,
+               unsigned long long max_connect_errors_timeout = routing::kDefaultMaxConnectErrorsTimeout,
                unsigned int connect_timeout = routing::kDefaultClientConnectTimeout,
                unsigned int net_buffer_length = routing::kDefaultNetBufferLength);
+
+  struct AuthErrorCounter {
+    size_t count;
+    std::time_t last_attempt;
+  };
 
   /** @brief Starts the service and accept incoming connections
    *
@@ -253,6 +261,8 @@ private:
   int destination_connect_timeout_;
   /** @brief Max connect errors blocking hosts when handshake not completed */
   unsigned long long max_connect_errors_;
+  /** @brief Timeout fot reset counter for connect errors blocking hosts when handshake not completed */
+  unsigned long long max_connect_errors_timeout_;
   /** @brief Timeout waiting for handshake response from client */
   unsigned int client_connect_timeout_;
   /** @brief Size of buffer to store receiving packets */
@@ -272,7 +282,7 @@ private:
 
   /** @brief Authentication error counters for IPv4 or IPv6 hosts */
   std::mutex mutex_auth_errors_;
-  std::map<std::array<uint8_t, 16>, size_t> auth_error_counters_;
+  std::map<std::array<uint8_t, 16>, AuthErrorCounter> auth_error_counters_;
   std::vector<std::array<uint8_t, 16>> blocked_client_hosts_;
 };
 

--- a/src/routing/src/plugin_config.cc
+++ b/src/routing/src/plugin_config.cc
@@ -38,6 +38,7 @@ string RoutingPluginConfig::get_default(const string &option) {
       {"connect_timeout", to_string(routing::kDefaultDestinationConnectionTimeout)},
       {"max_connections", to_string(routing::kDefaultMaxConnections)},
       {"max_connect_errors", to_string(routing::kDefaultMaxConnectErrors)},
+      {"max_connect_errors_timeout", to_string(routing::kDefaultMaxConnectErrorsTimeout)},
       {"client_connect_timeout", to_string(routing::kDefaultClientConnectTimeout)},
       {"net_buffer_length", to_string(routing::kDefaultNetBufferLength)},
   };

--- a/src/routing/src/plugin_config.h
+++ b/src/routing/src/plugin_config.h
@@ -53,6 +53,7 @@ public:
         mode(get_option_mode(section, "mode")),
         max_connections(get_uint_option<uint16_t>(section, "max_connections", 1)),
         max_connect_errors(get_uint_option<uint>(section, "max_connect_errors", 1, UINT32_MAX)),
+        max_connect_errors_timeout(get_uint_option<uint>(section, "max_connect_errors_timeout", 300, UINT32_MAX)), // 5 minutes for reset error attempts
         client_connect_timeout(get_uint_option<uint>(section, "client_connect_timeout", 2, 31536000)),
         net_buffer_length(get_uint_option<uint>(section, "net_buffer_length", 1024, 1048576)) { }
 
@@ -74,6 +75,8 @@ public:
   const int max_connections;
   /** @brief `max_connect_errors` option read from configuration section */
   const unsigned long long max_connect_errors;
+  /** @brief `max_connect_errors_timeout` option read from configuration section */
+  const unsigned long long max_connect_errors_timeout;
   /** @brief `client_connect_timeout` option read from configuration section */
   const unsigned int client_connect_timeout;
   /** @brief Size of buffer to receive packets */

--- a/src/routing/src/plugin_config.h
+++ b/src/routing/src/plugin_config.h
@@ -53,7 +53,7 @@ public:
         mode(get_option_mode(section, "mode")),
         max_connections(get_uint_option<uint16_t>(section, "max_connections", 1)),
         max_connect_errors(get_uint_option<uint>(section, "max_connect_errors", 1, UINT32_MAX)),
-        max_connect_errors_timeout(get_uint_option<uint>(section, "max_connect_errors_timeout", 300, UINT32_MAX)), // 5 minutes for reset error attempts
+        max_connect_errors_timeout(get_uint_option<uint>(section, "max_connect_errors_timeout", 0, UINT32_MAX)), // 5 minutes for reset error attempts
         client_connect_timeout(get_uint_option<uint>(section, "client_connect_timeout", 2, 31536000)),
         net_buffer_length(get_uint_option<uint>(section, "net_buffer_length", 1024, 1048576)) { }
 

--- a/src/routing/src/routing.cc
+++ b/src/routing/src/routing.cc
@@ -48,6 +48,7 @@ const int kDefaultDestinationConnectionTimeout = 1;
 const string kDefaultBindAddress = "127.0.0.1";
 const unsigned int kDefaultNetBufferLength = 16384;  // Default defined in latest MySQL Server
 const unsigned long long kDefaultMaxConnectErrors = 100;  // Similar to MySQL Server
+const unsigned long long kDefaultMaxConnectErrorsTimeout = 300;  // 5 minutes
 const unsigned int kDefaultClientConnectTimeout = 9; // Default connect_timeout MySQL Server minus 1
 
 const std::map<string, AccessMode> kAccessModeNames = {

--- a/src/routing/src/routing.cc
+++ b/src/routing/src/routing.cc
@@ -48,7 +48,7 @@ const int kDefaultDestinationConnectionTimeout = 1;
 const string kDefaultBindAddress = "127.0.0.1";
 const unsigned int kDefaultNetBufferLength = 16384;  // Default defined in latest MySQL Server
 const unsigned long long kDefaultMaxConnectErrors = 100;  // Similar to MySQL Server
-const unsigned long long kDefaultMaxConnectErrorsTimeout = 300;  // 5 minutes
+const unsigned long long kDefaultMaxConnectErrorsTimeout = 0;  // 5 minutes
 const unsigned int kDefaultClientConnectTimeout = 9; // Default connect_timeout MySQL Server minus 1
 
 const std::map<string, AccessMode> kAccessModeNames = {


### PR DESCRIPTION
There are 2 bugs:
1) When router tries to write to the closed socket, it gets signal SIGPIPE. The program will be terminated by default in this case (watch `man 7 signal`). To represent a bug at GNU Linux OS: 
- run mysqlrouter with routing at some port (ex. 7001)
- run telnet to the port and terminate it without any inputs with Ctrl+C

2) We don't cleanup a map with blocks notation (MySQLRouting::auth_error_counters_ (private)). If we have some problems at client side (or may be we check port without normal termination of socket or etc.) we block this client for perpetuity (client will be unblocked only if mysqlproxy restarts). But with the production system it is imposible. To represent a bug: 
- set max_connect_errors to 1
- run mysqlrouter with routing at some port (ex. 7001)
- run telnet to mysqlrouter port and exit from telnet normally
- run telnet again...

I've added option `max_connect_errors_timeout` to the routing plugin. This option doesn't affect to current behavior when it is set to 0 (we don't need to unblock clients).
