### PR TITLE
Add shebang to stop.sh

### DIFF
--- a/src/router/src/config_generator.cc
+++ b/src/router/src/config_generator.cc
@@ -1734,6 +1734,7 @@ void ConfigGenerator::create_start_scripts(const std::string &directory,
   if (script.fail()) {
     throw std::runtime_error("Could not open " + script_path + " for writing: " + get_strerror(errno));
   }
+  script << "#!/bin/bash\n";
   script << "if [ -f " + directory + "/mysqlrouter.pid ]; then\n";
   script << "  kill -HUP `cat " + directory + "/mysqlrouter.pid`\n";
   script << "  rm -f " << directory + "/mysqlrouter.pid\n";


### PR DESCRIPTION
I executed `stop.sh` on fish shell.
But it didn't work.

```
# ./stop.sh
Failed to execute process './stop.sh'. Reason:
exec: Exec format error
The file './stop.sh' is marked as an executable but could not be run by the operating system.
```

After that, I run `stop.sh` with bash. It succeeded.

```
# bash stop.sh
```

I edited `stop.sh` like `start.sh`.
It is adding shebang to `stop.sh`.

It was good solution for me.

### env

```
$ mysqlrouter --version
MySQL Router v2.1.6 on Linux (64-bit) (GPL community edition)
```

```
$ uname -a
Linux ubuntu-xenial 4.4.0-128-generic #154-Ubuntu SMP Fri May 25 14:15:18 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
```